### PR TITLE
docs/minor fixes in readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Ide
+.idea/
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ const mysqlDataLoader = async ({ cursor, first, encodeCursor }) => {
   // Fetch data from MySQL database
   const edges = fetchDataFromMySQL(cursor, first);
   return {
-    edges: edges.map(node => ({ node, cursor: encodeCursor({ node, getCursor }) })),
-    hasNextPage: checkIfHasNextPageInMySQL(),
+    edges: edges.map(node => ({ node, cursor: encodeCursor({ node, getCursor }) }))
   };
 };
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install paginated-connection
 Here is a basic example to get you started with Paginated Connection:
 
 ```typescript
-import { paginatedConnection, PaginationInput } from 'paginated-connection';
+const { paginatedConnection, PaginationInput } = require('@treedom/paginated-connection')
 
 // Define a simple node type
 type Node = {
@@ -108,7 +108,7 @@ console.log(result);
 Using Paginated Connection with MySQL:
 
 ```typescript
-import { mysqlPaginatedConnection } from 'paginated-connection';
+import { mysqlPaginatedConnection } from '@treedom/paginated-connection';
 
 // Define a simple node type
 type Node = {
@@ -154,7 +154,7 @@ In the MySQL implementation, the `+1` handling of data for the calculation of th
 Using Paginated Connection with MongoDB:
 
 ```typescript
-import { mongoDbPaginatedConnection } from 'paginated-connection';
+import { mongoDbPaginatedConnection } from '@treedom/paginated-connection';
 
 // Define a simple node type
 type Node = {
@@ -257,7 +257,7 @@ type CustomCursor = { after: string; sortField: string; sortOrder: 'asc' | 'desc
 When using a custom cursor type, you need to type the `paginatedConnection` (or `mysqlPaginatedConnection`, `mongoDbPaginatedConnection`, ecc...), providing cursor custom type:
 
 ```typescript
-import { paginatedConnection } from 'paginated-connection';
+import { paginatedConnection } from '@treedom/paginated-connection';
 
 type Node = {
   id: string;

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install @treedom/paginated-connection
 Here is a basic example to get you started with Paginated Connection:
 
 ```typescript
-const { paginatedConnection, PaginationInput } = require('@treedom/paginated-connection')
+import { paginatedConnection, PaginationInput } from '@treedom/paginated-connection'
 
 // Define a simple node type
 type Node = {

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Pagination is essential for managing large datasets in a user-friendly manner. P
 
 ## Installation
 
-To install Paginated Connection::
+To install Paginated Connection:
 
 ```sh
-npm install paginated-connection
+npm install @treedom/paginated-connection
 ```
 
 ## Usage


### PR DESCRIPTION
This PR will fix some issues in the **README.md** file.
- change module name in the examples from `paginated-connection` to `@treedom/paginated-connection`
- removed _hasNextPage_ returned field in mysqlPaginatedConnection example
