### PR TITLE
feat: add support of number and boolean types on custom cursor type

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,10 +309,13 @@ const result = await paginatedConnection<Node>({
 
 
 ### Custom Cursor Type
-For more complex scenarios, you can customize the cursor type to include additional fields, such as sorting information. The value of all cursor fields must be `string`.
+For more complex scenarios, you can customize the cursor type to include additional fields, such as sorting information. The value of all cursor fields must be one of the following:
+-  `string`
+-  `number`
+-  `boolean`
 
 ```typescript
-type CustomCursor = { after: string; sortField: string; sortOrder: 'asc' | 'desc' };
+type CustomCursor = { after: string; sortField: string; sortOrder: 'asc' | 'desc', ranking: number, includeMetadata: boolean };
 ```
 
 When using a custom cursor type, you need to type the `paginatedConnection` (or `mysqlPaginatedConnection`, `mongoDbPaginatedConnection`, ecc...), providing cursor custom type:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@treedom/paginated-connection",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Paginated connection utility library",
   "main": "./lib/index.js",
   "files": [

--- a/src/cursor/decodeCursor.ts
+++ b/src/cursor/decodeCursor.ts
@@ -1,10 +1,21 @@
-export const decodeCursor = <TCursor = { after: string }>(cursor: string) => {
+import { CursorValueType, TCursorValueBase } from '.'
+
+export const decodeCursor = <TCursor = TCursorValueBase>(cursor: string) => {
   try {
     const cursorParams = new URLSearchParams(
       Buffer.from(cursor, 'base64url').toString()
     ).entries()
 
-    return Object.fromEntries(cursorParams) as TCursor
+    const parsedCursor: Record<string, CursorValueType> = {}
+
+    for (const serializedCursorValue of [...cursorParams]) {
+      // Parse cursor value and attach to parse cursor object
+      parsedCursor[serializedCursorValue[0]] = JSON.parse(
+        serializedCursorValue[1]
+      ) // Deserialized value is CursorValueType. We use JSON.parse because could parse all handled primitive types
+    }
+
+    return parsedCursor as TCursor
   } catch (err) {
     return {} as TCursor
   }

--- a/src/cursor/decodeCursor.ts
+++ b/src/cursor/decodeCursor.ts
@@ -9,10 +9,10 @@ export const decodeCursor = <TCursor = TCursorValueBase>(cursor: string) => {
     const parsedCursor: Record<string, CursorValueType> = {}
 
     for (const serializedCursorValue of [...cursorParams]) {
-      // Parse cursor value and attach to parse cursor object
+      // Parse cursor value and attach to parsed cursor object
       parsedCursor[serializedCursorValue[0]] = JSON.parse(
         serializedCursorValue[1]
-      ) // Deserialized value is CursorValueType. We use JSON.parse because could parse all handled primitive types
+      ) // Deserialized value is CursorValueType. We use JSON.parse because could parse all handled types (string, number and boolean)
     }
 
     return parsedCursor as TCursor

--- a/src/cursor/encodeCursor.ts
+++ b/src/cursor/encodeCursor.ts
@@ -9,7 +9,8 @@ export const encodeCursor = <TNode, TCursor extends TCursorBase>({
   const cursorValues = getCursor(node)
 
   for (const key in cursorValues) {
-    cursorContent.append(key, cursorValues[key])
+    // Have to format the string in order to be able to parse in decoding function
+    cursorContent.append(key, JSON.stringify(cursorValues[key]))
   }
   return Buffer.from(cursorContent.toString()).toString('base64url')
 }

--- a/src/cursor/types.ts
+++ b/src/cursor/types.ts
@@ -1,4 +1,6 @@
-export type EncodeCursorProps<TNode, TCursor = { after: string }> = {
+export type CursorValueType = string | number | boolean
+
+export type EncodeCursorProps<TNode, TCursor = { after: CursorValueType }> = {
   node: TNode
   getCursor: (node: TNode) => TCursor
 }
@@ -7,6 +9,6 @@ export type EncodeCursor<TNode, TCursor> = (
   props: EncodeCursorProps<TNode, TCursor>
 ) => string
 
-export type TCursorValueBase = { after: string }
+export type TCursorValueBase = { after: CursorValueType }
 
-export type TCursorBase = TCursorValueBase & { [key: string]: string }
+export type TCursorBase = TCursorValueBase & { [key: string]: CursorValueType }

--- a/src/paginatedConnection.ts
+++ b/src/paginatedConnection.ts
@@ -24,7 +24,7 @@ export type GetEdges<TNode, TCursor> = (
   getCursor: (node: TNode) => TCursor
 ) => Array<PaginatedConnectionEdge<TNode>>
 
-export type DataloaderProps<TNode, TCursor = { after: string }> = {
+export type DataloaderProps<TNode, TCursor = TCursorValueBase> = {
   cursor?: TCursor
   first: number
   encodeCursor: EncodeCursor<TNode, TCursor>
@@ -32,7 +32,7 @@ export type DataloaderProps<TNode, TCursor = { after: string }> = {
   getEdges: GetEdges<TNode, TCursor>
 }
 
-export type CountLoaderProps<TCursor = { after: string }> = { cursor?: TCursor }
+export type CountLoaderProps<TCursor = TCursorValueBase> = { cursor?: TCursor }
 
 export type PaginationInput = {
   after?: string

--- a/src/paginatedConnectionMongoDb.ts
+++ b/src/paginatedConnectionMongoDb.ts
@@ -15,7 +15,7 @@ import {
 
 export type MongoDbPaginatedConnectionProps<
   TNode extends object,
-  TCursor = { after: string },
+  TCursor = TCursorValueBase,
 > = {
   dataLoader: (props: DataloaderProps<TNode, TCursor>) => Promise<{
     edges: { node: TNode; cursor: string }[]

--- a/src/paginatedConnectionMysql.ts
+++ b/src/paginatedConnectionMysql.ts
@@ -15,7 +15,7 @@ import {
 
 export type MysqlPaginatedConnectionProps<
   TNode extends object,
-  TCursor = { after: string },
+  TCursor = TCursorValueBase,
 > = {
   dataLoader: (props: DataloaderProps<TNode, TCursor>) => Promise<{
     edges: { node: TNode; cursor: string }[]

--- a/test/cursor/decodeCursor.test.ts
+++ b/test/cursor/decodeCursor.test.ts
@@ -33,3 +33,32 @@ tap.test("should return empty object when cursor isn't valid", async (t) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   t.same(decodeCursor(1111 as any), {})
 })
+
+tap.test(
+  'should return expected value with custom cursor with all handled value types',
+  async (t) => {
+    const decodedCursor = decodeCursor<{
+      after: string
+      ranking: number
+      enabled: boolean
+    }>('YWZ0ZXI9JTIyMSUyMiZlbmFibGVkPXRydWUmcmFua2luZz0xMTEx')
+    t.same(decodedCursor, {
+      after: '1',
+      enabled: true,
+      ranking: 1111,
+    })
+
+    t.ok(
+      typeof decodedCursor.after === 'string',
+      'should parse correctly string value'
+    )
+    t.ok(
+      typeof decodedCursor.ranking === 'number',
+      'should parse correctly number value'
+    )
+    t.ok(
+      typeof decodedCursor.enabled === 'boolean',
+      'should parse correctly boolean value'
+    )
+  }
+)

--- a/test/cursor/encodeCursor.test.ts
+++ b/test/cursor/encodeCursor.test.ts
@@ -11,7 +11,7 @@ tap.test('should return expected value with default cursor type', async (t) => {
         }
       },
     }),
-    'YWZ0ZXI9MQ'
+    'YWZ0ZXI9JTIyMSUyMg'
   )
 })
 
@@ -29,7 +29,7 @@ tap.test('should return expected value with custom cursor type', async (t) => {
         }
       },
     }),
-    'YWZ0ZXI9MSZzb3J0aW5nPTI'
+    'YWZ0ZXI9JTIyMSUyMiZzb3J0aW5nPSUyMjIlMjI'
   )
 })
 
@@ -54,7 +54,49 @@ tap.test(
           }
         },
       }),
-      'YWZ0ZXI9MSZzb3J0aW5nPTIy'
+      'YWZ0ZXI9JTIyMSUyMiZzb3J0aW5nPSUyMjIyJTIy'
+    )
+  }
+)
+
+tap.test(
+  'should return expected value with custom cursor with number field',
+  async (t) => {
+    t.equal(
+      encodeCursor<
+        { id: string; name: string },
+        { after: string; ranking: number }
+      >({
+        node: { id: '1', name: 'foobar' },
+        getCursor: () => {
+          return {
+            after: '1',
+            ranking: 1111,
+          }
+        },
+      }),
+      'YWZ0ZXI9JTIyMSUyMiZyYW5raW5nPTExMTE'
+    )
+  }
+)
+
+tap.test(
+  'should return expected value with custom cursor with boolean field',
+  async (t) => {
+    t.equal(
+      encodeCursor<
+        { id: string; name: string },
+        { after: string; enabled: boolean }
+      >({
+        node: { id: '1', name: 'foobar' },
+        getCursor: () => {
+          return {
+            after: '1',
+            enabled: true,
+          }
+        },
+      }),
+      'YWZ0ZXI9JTIyMSUyMiZlbmFibGVkPXRydWU'
     )
   }
 )


### PR DESCRIPTION
This PR will solve this [issue](https://github.com/treedomtrees/paginated-connection/issues/22).

The only thing I have to report is the increase in the cursor string size. To be able to keep using URLSearchParams as the format for the serialized cursor value, I had to add some extra data when the cursor field type is string.

The reason is that URLSearchParams always returns a string value. To parse it to the correct type (string, number, or boolean), I use JSON.parse. JSON.parse can recognize when a string is a stringified boolean or number and can parse it, but it has problems parsing actual strings. So, I had to wrap the string value inside a real string and assign it to the URLSearchParams value.

Example:

If you have a cursor like this:

typescript


```typescript
{
    after: '1',
    enabled: true,
    ranking: 1111,
}
```

You'll get a cursor `YWZ0ZXI9JTIyMSUyMiZlbmFibGVkPXRydWUmcmFua2luZz0xMTEx`, where base64decoded has value `after=%221%22&enabled=true&ranking=1111`



Closes #22 
  